### PR TITLE
Add a method for asserting request query parameters are correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+/.phpunit.result.cache

--- a/src/GuzzleMockResponse.php
+++ b/src/GuzzleMockResponse.php
@@ -116,6 +116,17 @@ class GuzzleMockResponse
         return $this;
     }
 
+    public function assertRequestQueryParameters(array $queryParameters)
+    {
+        $this->assertions[] = function (RequestInterface $request, ResponseInterface $response) use ($queryParameters) {
+            parse_str($request->getUri()->getQuery(), $passedQueryParameters);
+
+            Assert::assertEquals($queryParameters, $passedQueryParameters);
+        };
+
+        return $this;
+    }
+
     public function getWheres()
     {
         return $this->wheres;

--- a/tests/GuzzleMockHandlerTest.php
+++ b/tests/GuzzleMockHandlerTest.php
@@ -361,6 +361,19 @@ class GuzzleMockHandlerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_assert_query_parameters_match()
+    {
+        $handler = new GuzzleMockHandler;
+        $response = (new GuzzleMockResponse('dave/doug'))->assertRequestQueryParameters(['foo' => 'bar']);
+        $handler->expect($response);
+
+        $stack = HandlerStack::create($handler);
+        $guzzle = new Client(['handler' => $stack]);
+
+        $guzzle->get('dave/doug', ['query' => ['foo' => 'bar']]);
+    }
+
+    /** @test */
     public function match_fails_if_method_is_wrong()
     {
         $responseMock = new GuzzleMockResponse('dave/doug');
@@ -460,5 +473,4 @@ class GuzzleMockHandlerTest extends TestCase
 
         $this->assertTrue($responseMock->matches($request));
     }
-    
 }


### PR DESCRIPTION
Fixes: https://github.com/tomb1n0/guzzle-mock-handler/issues/4